### PR TITLE
Add has_many_base64_attached method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+Gemfile.lock

--- a/lib/active_storage_base64.rb
+++ b/lib/active_storage_base64.rb
@@ -1,3 +1,4 @@
 require 'active_storage_support/support_for_base64'
 require 'active_storage_support/base64_one'
+require 'active_storage_support/base64_many'
 require 'active_storage_support/base64_attach'

--- a/lib/active_storage_support/base64_many.rb
+++ b/lib/active_storage_support/base64_many.rb
@@ -1,0 +1,13 @@
+module ActiveStorageSupport
+  class Base64Many < ActiveStorage::Attached::Many
+    def attach(*attachables)
+      super base64_attachments(attachables)
+    end
+
+    def base64_attachments(attachments)
+      attachments.flatten.map do |attachment|
+        ActiveStorageSupport::Base64Attach.attachment_from_base64(data: attachment)
+      end
+    end
+  end
+end

--- a/lib/active_storage_support/support_for_base64.rb
+++ b/lib/active_storage_support/support_for_base64.rb
@@ -19,6 +19,21 @@ module ActiveStorageSupport
           end
         CODE
       end
+
+      def has_many_base64_attached(name, dependent: :purge_later)
+        has_many_attached name, dependent: dependent
+
+        class_eval <<-CODE, __FILE__, __LINE__ + 1
+          def #{name}
+            @active_storage_attached_#{name} ||=
+              ActiveStorageSupport::Base64Many.new("#{name}", self, dependent: #{dependent == :purge_later ? ":purge_later" : "false"})
+          end
+
+          def #{name}=(attachables)
+            #{name}.attach(attachables)
+          end
+        CODE
+      end
     end
   end
 end


### PR DESCRIPTION
Description:
- Added .gitignore file
- Ignored Gemfile.lock file as suggested on this [article](https://yehudakatz.com/2010/12/16/clarifying-the-roles-of-the-gemspec-and-gemfile/).
- Created the method `has_many_base64_attached`