### PR TITLE
symbolize keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,22 +67,7 @@ on your controller you could do something like this:
 class UsersController < ApplicationController
   def create
     user = User.create(user_params)
-  end
-
-  private
-
-  def user_params
-    params.require(:user).permit(:avatar[data:], :username, :email)
-  end
-end
-```
-
-Or you could also do:
-```ruby
-class UsersController < ApplicationController
-  def create
-    user = User.create(user_params)
-    user.avatar.attach(params[:avatar])
+    user.avatar.attach(data: params[:avatar])
   end
 
   private
@@ -98,7 +83,7 @@ Here's another option to achieve the same:
 class UsersController < ApplicationController
   def create
     user = User.create(user_params)
-    user.avatar = params[:avatar]
+    user.avatar = { data: params[:avatar] }
   end
 
   private
@@ -124,23 +109,6 @@ class UsersController < ApplicationController
 
   def user_params
     params.require(:user).permit(:username, :email)
-  end
-end
-```
-Or, in case you want to have the avatar attached as soon as the user is created you can do:
-```ruby
-class UsersController < ApplicationController
-  def create
-    user = User.create(user_params)
-  end
-
-  private
-
-  def user_params
-    params.require(:user).permit(:username, :email, avatar:[:data,
-                                                            :filename,
-                                                            :content_type,
-                                                            :identify])
   end
 end
 ```

--- a/active_storage_base64.gemspec
+++ b/active_storage_base64.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'active_storage_base64'
-  s.version = '0.1.1'
+  s.version = '0.1.2'
   s.summary = 'Base64 support for ActiveStorage'
   s.description = s.summary
 

--- a/lib/active_storage_support/base64_attach.rb
+++ b/lib/active_storage_support/base64_attach.rb
@@ -6,11 +6,11 @@ module ActiveStorageSupport
     def attachment_from_data(attachment)
       if attachment.is_a?(Hash)
         base64_data = attachment.delete(:data)
-        if base64_data.try(:is_a?, String) && base64_data =~ /^data:(.*?);(.*?),(.*)$/
 
+        if base64_data.try(:is_a?, String) && base64_data =~ /^data:(.*?);(.*?),(.*)$/
           attachment[:io] = StringIO.new(Base64.decode64(Regexp.last_match(3)))
-          attachment[:content_type] = Regexp.last_match(1) unless attachment[:content_type]
-          attachment[:filename] = Time.current.to_i.to_s unless attachment[:filename]
+          attachment[:content_type] ||= Regexp.last_match(1)
+          attachment[:filename]     ||= Time.current.to_i.to_s
         end
       end
 


### PR DESCRIPTION
Notes:
- This error popped when testing with the Megilla project using version `0.1.1` of the gem

Tasks:
- Increased version to `0.1.2`
- Modified readme since it contained a few errors
- Added `hash.symbolize_keys!` since when using a hash with string keys keys the method `attachment.delete(:data)` does not work, check the following example:
![image](https://user-images.githubusercontent.com/42209955/50690408-f0136b80-100b-11e9-810e-b6fd448d796e.png)
Also, even if using the `delete` method on a hash with string keys worked, when the attachment with string keys instead of symbols arrives to activestorage we receive the following error message:
```
     ArgumentError:
       wrong number of arguments (given 1, expected 0)
     # /Users/ricardocortio/.rvm/gems/ruby-2.4.1/gems/activestorage-5.2.2/app/models/active_storage/blob.rb:64:in `create_after_upload!'
```
so I checked how this was working on rails. It seems the method `create_blob_from` has the following lines:
```ruby
when Hash
  ActiveStorage::Blob.create_after_upload!(attachable)
```
and the method `create_after_upload!` receives keyword arguments, not positional arguments
```ruby
    def create_after_upload!(io:, filename:, content_type: nil, metadata: nil)
      build_after_upload(io: io, filename: filename, content_type: content_type, metadata: metadata).tap(&:save!)
    end
```
therefore when this hash was sent to this method we would get the previously mentioned argument error.
- After this change, the ABC for `attachment_from_data` got to 15.39/15, so I had to do some refactoring