### PR TITLE
Fixed gem name

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Gem used to add support for base64 images for Rails's ActiveStorage.
 
 In order to get the gem working on your project you just need to add the gem to your project like this:
 ```ruby
-gem 'active-storage-base64'
+gem 'active_storage_base64'
 ```
 
 ### Prerequisites


### PR DESCRIPTION
I tried adding the gem to my project but was unable to do so from the readme file. I decided to check the gemspec and there I saw that the name given in the readme file is misspelled.

This is my first PR to any project 😄 

Kindly advise if anything seems out of place.