### PR TITLE
Support Rails 5.2.x

### DIFF
--- a/active_storage_base64.gemspec
+++ b/active_storage_base64.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = ">= 2.2.2"
 
   # Dependencies
-  s.add_dependency 'rails', '~> 5.2.0', '<= 5.2.2'
+  s.add_dependency 'rails', '~> 5.2'
 
   # Development dependencies
   s.add_development_dependency 'rubocop', '~> 0.56.0'


### PR DESCRIPTION
This will allow support for all 5.2.x versions of Rails. Manually tested against 5.2.2.1.