### PR TITLE
symbolize attachment keys

### DIFF
--- a/lib/active_storage_support/base64_attach.rb
+++ b/lib/active_storage_support/base64_attach.rb
@@ -4,7 +4,10 @@ module ActiveStorageSupport
     module_function
 
     def attachment_from_data(attachment)
-      fill_attachment_data(attachment, attachment.delete(:data)) if attachment.is_a?(Hash)
+      if attachment.is_a?(Hash)
+        attachment = attachment.symbolize_keys
+        fill_attachment_data(attachment, attachment.delete(:data))
+      end
 
       attachment
     end


### PR DESCRIPTION
When passing ActionController::Parameters to the model with the attached base64 file the hash keys are strings, which seems currently not to be expected.

Example usage:

```ruby
# user.rb
class User < ApplicationRecord
  include ActiveStorageSupport::SupportForBase64

  has_one_base64_attached :avatar
end
```

```ruby
# users_controller.rb
def create
  @user = User.new(user_params)
  @user.save
end

def user_params
  params.require(:user).permit(:email, :password, :password_confirmation, avatar: [:data])
end
```