### PR TITLE
Add Data Format section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,26 +4,22 @@
 
 # ActiveStorageBase64
 
-Gem used to add support for base64 images for Rails's ActiveStorage.
+Adds support for base64 attachments to ActiveStorage.
 
-## Getting Started
+## Installation
 
 In order to get the gem working on your project you just need to add the gem to your project like this:
 ```ruby
 gem 'active_storage_base64'
 ```
 
-### Prerequisites
+## Prerequisites
 
-The only two prerequisites for using this gem are having Rails version 5.2.0 or higher installed on your project and having ActiveStorage setup properly (for more information on how to do this, check this [Active Storage Overview](https://edgeguides.rubyonrails.org/active_storage_overview.html))
+The only prerequisites for using this gem are having Rails version 5.2.0 or higher installed on your project and having ActiveStorage properly set up (for more information on how to do this, check [Active Storage Overview](https://edgeguides.rubyonrails.org/active_storage_overview.html))
 
-```ruby
-gem 'rails', '5.2.0'
-```
+## Usage
 
-### Installing
-
-In order to use the gem's functionality, you'll need to include the module into your ActiveRecord inheriting class.
+In order to use the gem's functionality, you need to include the `ActiveStorageSupport::SupportForBase64` module in your ActiveRecord models.
 For example:
 ```ruby
 class User < ActiveRecord::Base
@@ -32,7 +28,7 @@ end
 ```
 
 Note:
-We highly recomment using an alternative class that inherits from ActiveRecord and includes the module so instead of including the module for each of your classes, you make them inherit from this new class, check below:
+We highly recommend using an alternative class that inherits from `ActiveRecord::Base` and includes the module so instead of including the module for each of your classes, you make them inherit from this new class, check below:
 ```ruby
 class ApplicationRecord < ActiveRecord::Base
   include ActiveStorageSupport::SupportForBase64
@@ -43,7 +39,7 @@ class User < ApplicationRecord
 end
 ```
 
-After you have the module included in your class you'll be able to use the following two helper methods for working with base64 files:
+After you have the module included in your class you'll be able to use the following two helper methods to work with base64 files:
 When you need a single image attached:
 ```ruby
 has_one_base64_attached
@@ -54,7 +50,7 @@ has_many_base64_attached
 ```
 These helpers will work just like the `has_one_attached` and `has_many_attached` helper methods from ActiveStorage.
 
-A working example for this, assuming we have a model `User` with only an `avatar` attached would be:
+A working example for this, assuming we have a model `User` with an `avatar` attached would be:
 ```ruby
 class User < ActiveRecord::Base
   include ActiveStorageSupport::SupportForBase64
@@ -110,9 +106,9 @@ class UsersController < ApplicationController
 end
 ```
 
-## Specifying a filename or content_type
+### Specifying a filename or content type
 
-If you are willing to add a specific filename to your attachment, or send in a specific content_type for your file, you can use `data:` to attach the base64 data and specify your `filename:`, `content_type:` and/or `identify:` hash keys.
+If you are willing to add a specific filename to your attachment, or send in a specific content type for your file, you can use `data:` to attach the base64 data and specify your `filename:`, `content_type:` and/or `identify:` hash keys.
 Check the following example:
 ```ruby
 class UsersController < ApplicationController
@@ -147,7 +143,13 @@ class UsersController < ApplicationController
 end
 ```
 
-For more information on how to work with ActiveStorage, please check the [Active Storage Overview](https://edgeguides.rubyonrails.org/active_storage_overview.html) mentioned above, all points in there apply to this gem as well.
+### Data Format
+
+To attach base64 data it is required to come in the form of [Data URIs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs) .
+For example:
+```
+data:image/png;base64,[base64 data]
+```
 
 ## Contributing
 


### PR DESCRIPTION
This PR tries to improve the README in general and it also clarifies what have been source of confusion in https://github.com/rootstrap/active-storage-base64/issues/25 and https://github.com/rootstrap/active-storage-base64/issues/28 , the format of the base64 data.