### PR TITLE
Allow failures in ruby-head

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,10 @@ rvm:
   - 2.5.0
   - ruby-head
 
+matrix:
+  allow_failures:
+    - rvm: ruby-head
+
 sudo: false
 
 env:


### PR DESCRIPTION
It's a common practice to allow ruby-head to fail since it's not a stable release.

It has been failing for some days, seems like it's a `reek` issue, not ours.