### PR TITLE
Variants support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,9 +8,13 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        gemfile: [rails_6_1.gemfile, rails_head.gemfile]
+        gemfile: [rails_6_1.gemfile, rails_7_0.gemfile, rails_head.gemfile]
         ruby_version: [2.5, 2.6, 2.7, 3.0]
         exclude:
+          - gemfile: rails_7_0.gemfile
+            ruby_version: 2.5
+          - gemfile: rails_7_0.gemfile
+            ruby_version: 2.6
           - gemfile: rails_head.gemfile
             ruby_version: 2.5
           - gemfile: rails_head.gemfile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,17 +8,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        gemfile: [rails_6_1.gemfile, rails_7_0.gemfile, rails_head.gemfile]
-        ruby_version: [2.5, 2.6, 2.7, 3.0]
-        exclude:
-          - gemfile: rails_7_0.gemfile
-            ruby_version: 2.5
-          - gemfile: rails_7_0.gemfile
-            ruby_version: 2.6
-          - gemfile: rails_head.gemfile
-            ruby_version: 2.5
-          - gemfile: rails_head.gemfile
-            ruby_version: 2.6
+        gemfile: [rails_7_0.gemfile, rails_head.gemfile]
+        ruby_version: [2.7, 3.0]
     env:
       BUNDLE_GEMFILE: gemfiles/${{ matrix.gemfile }}
       CC_TEST_REPORTER_ID: 7196b4aa257fde33f24463218af32db6a6efd23d9148204822f757fa614a093e

--- a/active_storage_base64.gemspec
+++ b/active_storage_base64.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'active_storage_base64'
-  s.version = '1.2.0'
+  s.version = '2.0.0'
   s.summary = 'Base64 support for ActiveStorage'
   s.description = s.summary
 

--- a/active_storage_base64.gemspec
+++ b/active_storage_base64.gemspec
@@ -24,4 +24,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rubocop', '~> 1.22.0'
   s.add_development_dependency 'simplecov', '~> 0.17.1'
   s.add_development_dependency 'sqlite3', '1.4.2'
+  s.add_development_dependency 'image_processing', '~> 1.2'
 end

--- a/active_storage_base64.gemspec
+++ b/active_storage_base64.gemspec
@@ -7,15 +7,15 @@ Gem::Specification.new do |s|
   s.files = Dir['LICENSE.txt', 'README.md', 'lib/**/*']
 
   s.require_paths = ['lib']
-  s.authors = ['Ricardo Cortio']
+  s.authors = ['Ricardo Cortio', 'Santiago Bartesaghi']
   s.license = 'MIT'
   s.homepage = 'https://github.com/rootstrap/active-storage-base64'
-  s.email = 'ricardo@rootstrap.com'
+  s.email = ['ricardo@rootstrap.com', 'santiago.bartesaghi@rootstrap.com']
 
-  s.required_ruby_version = '>= 2.5.0'
+  s.required_ruby_version = '>= 2.7.0'
 
   # Dependencies
-  s.add_dependency 'rails', '>= 6.1'
+  s.add_dependency 'rails', '>= 7.0'
 
   # Development dependencies
   s.add_development_dependency 'pry-rails', '~> 0.3.6'

--- a/bug_report_template.rb
+++ b/bug_report_template.rb
@@ -8,9 +8,9 @@ gemfile(true) do
   git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
   # Activate the gem you are reporting the issue against.
-  gem 'rails', '~> 6.1'
+  gem 'rails', '~> 7.0'
   gem 'sqlite3'
-  gem 'active_storage_base64', '~> 1.2.0'
+  gem 'active_storage_base64', '~> 2.0.0'
 end
 
 require 'active_record/railtie'

--- a/gemfiles/rails_6_1.gemfile
+++ b/gemfiles/rails_6_1.gemfile
@@ -1,5 +1,0 @@
-source 'https://rubygems.org'
-
-gem 'rails', '~> 6.1.0'
-
-gemspec path: '..'

--- a/gemfiles/rails_7_0.gemfile
+++ b/gemfiles/rails_7_0.gemfile
@@ -1,0 +1,5 @@
+source 'https://rubygems.org'
+
+gem 'rails', '~> 7.0.0'
+
+gemspec path: '..'

--- a/lib/active_storage_support/support_for_base64.rb
+++ b/lib/active_storage_support/support_for_base64.rb
@@ -5,8 +5,8 @@ module ActiveStorageSupport
   module SupportForBase64
     extend ActiveSupport::Concern
     class_methods do
-      def has_one_base64_attached(name, dependent: :purge_later, service: nil, strict_loading: false)
-        has_one_attached name, dependent: dependent, service: service, strict_loading: strict_loading
+      def has_one_base64_attached(name, dependent: :purge_later, service: nil, strict_loading: false, &block)
+        has_one_attached name, dependent: dependent, service: service, strict_loading: strict_loading, &block
 
         generated_association_methods.class_eval <<-CODE, __FILE__, __LINE__ + 1
           # frozen_string_literal: true
@@ -28,8 +28,8 @@ module ActiveStorageSupport
         CODE
       end
 
-      def has_many_base64_attached(name, dependent: :purge_later, service: nil, strict_loading: false)
-        has_many_attached name, dependent: dependent, service: service, strict_loading: strict_loading
+      def has_many_base64_attached(name, dependent: :purge_later, service: nil, strict_loading: false, &block)
+        has_many_attached name, dependent: dependent, service: service, strict_loading: strict_loading, &block
 
         generated_association_methods.class_eval <<-CODE, __FILE__, __LINE__ + 1
           # frozen_string_literal: true

--- a/spec/dummy/app/models/user.rb
+++ b/spec/dummy/app/models/user.rb
@@ -1,4 +1,9 @@
 class User < ApplicationRecord
-  has_one_base64_attached :avatar
-  has_many_base64_attached :pictures
+  has_one_base64_attached :avatar do |attachable|
+    attachable.variant :thumb, resize_to_fit: [1, 1]
+  end
+
+  has_many_base64_attached :pictures do |attachable|
+    attachable.variant :thumb, resize_to_fit: [1, 1]
+  end
 end

--- a/spec/user_base64_spec.rb
+++ b/spec/user_base64_spec.rb
@@ -250,6 +250,16 @@ RSpec.describe 'Attach base64' do
         end
       end
     end
+
+    context 'when using a variant' do
+      let(:user) { User.create!(avatar: base64_data) }
+
+      it 'returns a link' do
+        url = rails_url.rails_blob_url(user.avatar.variant(:thumb).processed)
+
+        expect(url).to be
+      end
+    end
   end
 
   context 'when user uses pictures' do
@@ -600,13 +610,13 @@ RSpec.describe 'Attach base64' do
         context 'when a single picture is passed' do
           context 'when only data is specified' do
             it 'attaches a picture' do
-              user = User.create(pictures: base64_data)
+              user = User.create!(pictures: base64_data)
 
               expect(user.pictures.attached?).to be
             end
 
             it 'attached file matches attachment file' do
-              user = User.create(pictures: base64_data)
+              user = User.create!(pictures: base64_data)
 
               expect(
                 File.open(ActiveStorage::Blob.service.send(:path_for,
@@ -617,7 +627,7 @@ RSpec.describe 'Attach base64' do
 
           context 'when a filename is specified' do
             it 'assigns the specified filename' do
-              user = User.create(pictures: data_with_filename)
+              user = User.create!(pictures: data_with_filename)
 
               expect(user.pictures.first.filename.to_s).to eq(filename)
             end
@@ -626,7 +636,7 @@ RSpec.describe 'Attach base64' do
 
         context 'when an array of pictures is passed' do
           it 'attaches multiple pictures' do
-            user = User.create(pictures: attachments_with_filename)
+            user = User.create!(pictures: attachments_with_filename)
 
             expect(user.pictures.first.filename.to_s).to eq(filename)
             expect(user.pictures.second.filename.to_s).to eq(second_filename)
@@ -652,13 +662,13 @@ RSpec.describe 'Attach base64' do
         context 'when a single picture is passed' do
           context 'when only data is specified' do
             it 'attaches a picture' do
-              user = User.create(pictures: base64_data)
+              user = User.create!(pictures: base64_data)
 
               expect(user.pictures.attached?).to be
             end
 
             it 'attached file matches attachment file' do
-              user = User.create(pictures: base64_data)
+              user = User.create!(pictures: base64_data)
 
               expect(
                 File.open(ActiveStorage::Blob.service.send(:path_for,
@@ -669,7 +679,7 @@ RSpec.describe 'Attach base64' do
 
           context 'when a filename is specified' do
             it 'assigns the specified filename' do
-              user = User.create(pictures: data_with_filename)
+              user = User.create!(pictures: data_with_filename)
 
               expect(user.pictures.first.filename.to_s).to eq(filename)
             end
@@ -678,7 +688,7 @@ RSpec.describe 'Attach base64' do
 
         context 'when an array of pictures is passed' do
           it 'attaches multiple pictures' do
-            user = User.create(pictures: attachments_with_filename)
+            user = User.create!(pictures: attachments_with_filename)
 
             expect(user.pictures.first.filename.to_s).to eq(filename)
             expect(user.pictures.second.filename.to_s).to eq(second_filename)
@@ -694,7 +704,7 @@ RSpec.describe 'Attach base64' do
           end
 
           context 'when user has only one picture attached' do
-            let(:user) { User.create(pictures: base64_data) }
+            let(:user) { User.create!(pictures: base64_data) }
 
             context 'when the user wants to remove the picture' do
               it 'removes the picture' do
@@ -706,7 +716,7 @@ RSpec.describe 'Attach base64' do
           end
 
           context 'when user has multiple pictures attached' do
-            let(:user) { User.create(pictures: pictures_attachments) }
+            let(:user) { User.create!(pictures: pictures_attachments) }
 
             context 'when user wants to remove the pictures' do
               it 'removes the pictures' do
@@ -788,7 +798,7 @@ RSpec.describe 'Attach base64' do
             params.permit(:data)
           end
           context 'when user has only one picture attached' do
-            let(:user) { User.create(pictures: base64_data) }
+            let(:user) { User.create!(pictures: base64_data) }
 
             context 'when the user wants to remove the picture' do
               it 'removes the picture' do
@@ -800,7 +810,7 @@ RSpec.describe 'Attach base64' do
           end
 
           context 'when user has multiple pictures attached' do
-            let(:user) { User.create(pictures: pictures_attachments) }
+            let(:user) { User.create!(pictures: pictures_attachments) }
 
             context 'when user wants to remove the pictures' do
               it 'removes the pictures' do
@@ -866,6 +876,16 @@ RSpec.describe 'Attach base64' do
             end
           end
         end
+      end
+    end
+
+    context 'when using a variant' do
+      let(:user) { User.create!(pictures: base64_data) }
+
+      it 'returns a link' do
+        url = rails_url.rails_blob_url(user.pictures.first.variant(:thumb).processed)
+
+        expect(url).to be
       end
     end
   end

--- a/spec/user_file_spec.rb
+++ b/spec/user_file_spec.rb
@@ -52,13 +52,13 @@ RSpec.describe 'Attach file' do
 
       context 'when the avatar is sent as a hash parameter to the user' do
         it 'attaches an avatar to the user' do
-          user = User.create(avatar: file)
+          user = User.create!(avatar: file)
 
           expect(user.avatar.attached?).to be
         end
 
         it 'assigns the specified filename' do
-          user = User.create(avatar: file)
+          user = User.create!(avatar: file)
 
           expect(user.avatar.filename.to_s).to eq(filename)
         end
@@ -74,7 +74,7 @@ RSpec.describe 'Attach file' do
     end
 
     context 'when user has an avatar attached' do
-      let(:user) { User.create(avatar: file) }
+      let(:user) { User.create!(avatar: file) }
 
       context 'when the user wants to remove the avatar' do
         it 'removes the avatar' do
@@ -90,6 +90,16 @@ RSpec.describe 'Attach file' do
 
           expect(url).to be
         end
+      end
+    end
+
+    context 'when using a variant' do
+      let(:user) { User.create!(avatar: file) }
+
+      it 'returns a link' do
+        url = rails_url.rails_blob_url(user.avatar.variant(:thumb).processed)
+
+        expect(url).to be
       end
     end
   end
@@ -218,13 +228,13 @@ RSpec.describe 'Attach file' do
       context 'when pictures are passed as a hash parameter' do
         context 'when a single picture is passed' do
           it 'attaches a picture' do
-            user = User.create(pictures: file)
+            user = User.create!(pictures: file)
 
             expect(user.pictures.attached?).to be
           end
 
           it 'assigns the specified filename' do
-            user = User.create(pictures: file)
+            user = User.create!(pictures: file)
 
             expect(user.pictures.first.filename).to eq(filename)
           end
@@ -232,13 +242,13 @@ RSpec.describe 'Attach file' do
 
         context 'when an array of pictures is passed' do
           it 'attaches multiple pictures' do
-            user = User.create(pictures: pictures_attachments)
+            user = User.create!(pictures: pictures_attachments)
 
             expect(user.pictures.count).to eq(2)
           end
 
           it 'assigns the specified filename' do
-            user = User.create(pictures: pictures_attachments)
+            user = User.create!(pictures: pictures_attachments)
 
             expect(user.pictures.first.filename).to eq(filename)
             expect(user.pictures.second.filename).to eq(second_filename)
@@ -248,7 +258,7 @@ RSpec.describe 'Attach file' do
 
       context 'when user already has pictures attached' do
         context 'when user has only one picture attached' do
-          let(:user) { User.create(pictures: file) }
+          let(:user) { User.create!(pictures: file) }
 
           context 'when the user wants to remove the picture' do
             it 'removes the picture' do
@@ -260,7 +270,7 @@ RSpec.describe 'Attach file' do
         end
 
         context 'when user has multiple pictures attached' do
-          let(:user) { User.create(pictures: pictures_attachments) }
+          let(:user) { User.create!(pictures: pictures_attachments) }
 
           context 'when user wants to remove the pictures' do
             it 'removes the pictures' do
@@ -285,6 +295,16 @@ RSpec.describe 'Attach file' do
             end
           end
         end
+      end
+    end
+
+    context 'when using a variant' do
+      let(:user) { User.create!(pictures: pictures_attachments) }
+
+      it 'returns a link' do
+        url = rails_url.rails_blob_url(user.pictures.first.variant(:thumb).processed)
+
+        expect(url).to be
       end
     end
   end


### PR DESCRIPTION
Fixes #68

It also drops support for Rails 6.1 since the API is different. I think this is fine since Rails 6.1 users can continue to use `v1.2.0` of the gem. Otherwise, if we want to keep support, we'll need to maintain 2 dummy apps for the specs (one for Rails 6.1 and another one for Rails 7.0).