### PR TITLE
fix: allow empty hash to nullify attachable

### DIFF
--- a/lib/active_storage_support/support_for_base64.rb
+++ b/lib/active_storage_support/support_for_base64.rb
@@ -17,7 +17,7 @@ module ActiveStorageSupport
 
           def #{name}=(attachable)
             attachment_changes["#{name}"] =
-              if attachable.nil?
+              if attachable.presence.nil?
                 ActiveStorage::Attached::Changes::DeleteOne.new("#{name}", self)
               else
                 ActiveStorage::Attached::Changes::CreateOne.new(


### PR DESCRIPTION
### Summary

When a params is sent as null, the `attachable.nil?` will be false and I cannot nullify the attachment.

### Other Information

I'm not sure if this behavior is intended, but I made the change in our repo and want to make one here. If it's not applicable you can just close it. Thanks for the gem.