### PR TITLE
fix: drop Rails dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ spec/dummy/log
 spec/dummy/db/**.sqlite3
 spec/dummy/tmp/storage/**/*
 /coverage/
+.bundle

--- a/active_storage_base64.gemspec
+++ b/active_storage_base64.gemspec
@@ -15,9 +15,11 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 2.7.0'
 
   # Dependencies
-  s.add_dependency 'rails', '>= 7.0'
+  s.add_dependency 'activestorage', '>= 7.0'
+  s.add_dependency 'activesupport', '>= 7.0'
 
   # Development dependencies
+  s.add_development_dependency 'rails', '>= 7.0'
   s.add_development_dependency 'pry-rails', '~> 0.3.6'
   s.add_development_dependency 'reek', '~> 6.0.6'
   s.add_development_dependency 'rspec-rails', '~> 3.8.0'


### PR DESCRIPTION
### Summary

I believe that a dependency on the whole rails gem is redundant, I saw gems that needed rails engines and stuff and they indeed required railties not rails as a dependency. This gem doesn't require event railties, so why not drop rails and add what it needs: `activestorage` and `activestorage`.
