### PR TITLE
Add support to Rails 7.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,8 +8,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        gemfile: [rails_7_0.gemfile, rails_head.gemfile]
-        ruby_version: [2.7, 3.0]
+        gemfile: [rails_7_1.gemfile, rails_head.gemfile]
+        ruby_version: [2.7, 3.0, 3.1, 3.2]
     env:
       BUNDLE_GEMFILE: gemfiles/${{ matrix.gemfile }}
       CC_TEST_REPORTER_ID: 7196b4aa257fde33f24463218af32db6a6efd23d9148204822f757fa614a093e

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ gem 'active_storage_base64'
 ## Compatibility
 Rails Version | ActiveStorageBase64 Version
 --------------|-----------------------------
+7.1.x         | 3.0.x
 7.0.x         | 2.0.x
 6.1.x         | 1.2.x
 6.0.x         | 1.1.x

--- a/active_storage_base64.gemspec
+++ b/active_storage_base64.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 2.7.0'
 
   # Dependencies
-  s.add_dependency 'rails', '>= 7.1'
+  s.add_dependency 'rails', '> 7.0'
 
   # Development dependencies
   s.add_development_dependency 'pry-rails', '~> 0.3.6'

--- a/active_storage_base64.gemspec
+++ b/active_storage_base64.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'active_storage_base64'
-  s.version = '2.0.0'
+  s.version = '3.0.0'
   s.summary = 'Base64 support for ActiveStorage'
   s.description = s.summary
 
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 2.7.0'
 
   # Dependencies
-  s.add_dependency 'rails', '>= 7.0'
+  s.add_dependency 'rails', '>= 7.1'
 
   # Development dependencies
   s.add_development_dependency 'pry-rails', '~> 0.3.6'

--- a/bug_report_template.rb
+++ b/bug_report_template.rb
@@ -8,9 +8,9 @@ gemfile(true) do
   git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
   # Activate the gem you are reporting the issue against.
-  gem 'rails', '~> 7.0'
+  gem 'rails', '~> 7.1'
   gem 'sqlite3'
-  gem 'active_storage_base64', '~> 2.0.0'
+  gem 'active_storage_base64', '~> 3.0.0'
 end
 
 require 'active_record/railtie'

--- a/gemfiles/rails_7_1.gemfile
+++ b/gemfiles/rails_7_1.gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
 
-gem 'rails', '~> 7.1.0'
+gem 'rails', '~> 7.1.0.beta1'
 
 gemspec path: '..'

--- a/gemfiles/rails_7_1.gemfile
+++ b/gemfiles/rails_7_1.gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
 
-gem 'rails', '~> 7.0.0'
+gem 'rails', '~> 7.1.0'
 
 gemspec path: '..'

--- a/spec/user_base64_spec.rb
+++ b/spec/user_base64_spec.rb
@@ -446,14 +446,14 @@ RSpec.describe 'Attach base64' do
           context 'when it is called with only one picture' do
             context 'when only data is specified' do
               it 'attaches a picture to the user' do
-                user.pictures = base64_data
+                user.pictures = [base64_data]
                 user.save
 
                 expect(user.pictures.attached?).to be
               end
 
               it 'attached file matches attachment file' do
-                user.pictures = base64_data
+                user.pictures = [base64_data]
                 user.save
 
                 expect(
@@ -465,7 +465,7 @@ RSpec.describe 'Attach base64' do
 
             context 'when filename is specified' do
               it 'assigns the specified filename' do
-                user.pictures = data_with_filename
+                user.pictures = [data_with_filename]
                 user.save
 
                 expect(user.pictures.first.filename.to_s).to eq(filename)
@@ -531,14 +531,14 @@ RSpec.describe 'Attach base64' do
           context 'when it is called with only one picture' do
             context 'when only data is specified' do
               it 'attaches a picture to the user' do
-                user.pictures = base64_data
+                user.pictures = [base64_data]
                 user.save
 
                 expect(user.pictures.attached?).to be
               end
 
               it 'attached file matches attachment file' do
-                user.pictures = base64_data
+                user.pictures = [base64_data]
                 user.save
 
                 expect(
@@ -550,7 +550,7 @@ RSpec.describe 'Attach base64' do
 
             context 'when filename is specified' do
               it 'assigns the specified filename' do
-                user.pictures = data_with_filename
+                user.pictures = [data_with_filename]
                 user.save
 
                 expect(user.pictures.first.filename.to_s).to eq(filename)
@@ -610,13 +610,13 @@ RSpec.describe 'Attach base64' do
         context 'when a single picture is passed' do
           context 'when only data is specified' do
             it 'attaches a picture' do
-              user = User.create!(pictures: base64_data)
+              user = User.create!(pictures: [base64_data])
 
               expect(user.pictures.attached?).to be
             end
 
             it 'attached file matches attachment file' do
-              user = User.create!(pictures: base64_data)
+              user = User.create!(pictures: [base64_data])
 
               expect(
                 File.open(ActiveStorage::Blob.service.send(:path_for,
@@ -627,7 +627,7 @@ RSpec.describe 'Attach base64' do
 
           context 'when a filename is specified' do
             it 'assigns the specified filename' do
-              user = User.create!(pictures: data_with_filename)
+              user = User.create!(pictures: [data_with_filename])
 
               expect(user.pictures.first.filename.to_s).to eq(filename)
             end
@@ -662,13 +662,13 @@ RSpec.describe 'Attach base64' do
         context 'when a single picture is passed' do
           context 'when only data is specified' do
             it 'attaches a picture' do
-              user = User.create!(pictures: base64_data)
+              user = User.create!(pictures: [base64_data])
 
               expect(user.pictures.attached?).to be
             end
 
             it 'attached file matches attachment file' do
-              user = User.create!(pictures: base64_data)
+              user = User.create!(pictures: [base64_data])
 
               expect(
                 File.open(ActiveStorage::Blob.service.send(:path_for,
@@ -679,7 +679,7 @@ RSpec.describe 'Attach base64' do
 
           context 'when a filename is specified' do
             it 'assigns the specified filename' do
-              user = User.create!(pictures: data_with_filename)
+              user = User.create!(pictures: [data_with_filename])
 
               expect(user.pictures.first.filename.to_s).to eq(filename)
             end
@@ -704,7 +704,7 @@ RSpec.describe 'Attach base64' do
           end
 
           context 'when user has only one picture attached' do
-            let(:user) { User.create!(pictures: base64_data) }
+            let(:user) { User.create!(pictures: [base64_data]) }
 
             context 'when the user wants to remove the picture' do
               it 'removes the picture' do
@@ -747,38 +747,10 @@ RSpec.describe 'Attach base64' do
               end
             end
 
-            context 'when replacing on assign' do
-              before do
-                @previous = ActiveStorage.replace_on_assign_to_many
-                ActiveStorage.replace_on_assign_to_many = true
-              end
-
-              after do
-                ActiveStorage.replace_on_assign_to_many = @previous
-              end
-
-              it 'updates the existing record replacing attachments' do
-                user.pictures = pictures_attachments
-                user.save
-                expect(user.pictures.count).to eq(2)
-              end
-            end
-
-            context 'when appending on assign' do
-              before do
-                @previous = ActiveStorage.replace_on_assign_to_many
-                ActiveStorage.replace_on_assign_to_many = false
-              end
-
-              after do
-                ActiveStorage.replace_on_assign_to_many = @previous
-              end
-
-              it 'updates the existing record appending the new attachments' do
-                user.pictures = pictures_attachments
-                user.save
-                expect(user.pictures.count).to eq(4)
-              end
+            it 'updates the existing record replacing attachments' do
+              user.pictures = pictures_attachments
+              user.save
+              expect(user.pictures.count).to eq(2)
             end
           end
         end
@@ -798,7 +770,7 @@ RSpec.describe 'Attach base64' do
             params.permit(:data)
           end
           context 'when user has only one picture attached' do
-            let(:user) { User.create!(pictures: base64_data) }
+            let(:user) { User.create!(pictures: [base64_data]) }
 
             context 'when the user wants to remove the picture' do
               it 'removes the picture' do
@@ -841,38 +813,10 @@ RSpec.describe 'Attach base64' do
               end
             end
 
-            context 'when replacing on assign' do
-              before do
-                @previous = ActiveStorage.replace_on_assign_to_many
-                ActiveStorage.replace_on_assign_to_many = true
-              end
-
-              after do
-                ActiveStorage.replace_on_assign_to_many = @previous
-              end
-
-              it 'updates the existing record replacing attachments' do
-                user.pictures = pictures_attachments
-                user.save
-                expect(user.pictures.count).to eq(2)
-              end
-            end
-
-            context 'when appending on assign' do
-              before do
-                @previous = ActiveStorage.replace_on_assign_to_many
-                ActiveStorage.replace_on_assign_to_many = false
-              end
-
-              after do
-                ActiveStorage.replace_on_assign_to_many = @previous
-              end
-
-              it 'updates the existing record appending the new attachments' do
-                user.pictures = pictures_attachments
-                user.save
-                expect(user.pictures.count).to eq(4)
-              end
+            it 'updates the existing record replacing attachments' do
+              user.pictures = pictures_attachments
+              user.save
+              expect(user.pictures.count).to eq(2)
             end
           end
         end
@@ -880,7 +824,7 @@ RSpec.describe 'Attach base64' do
     end
 
     context 'when using a variant' do
-      let(:user) { User.create!(pictures: base64_data) }
+      let(:user) { User.create!(pictures: [base64_data]) }
 
       it 'returns a link' do
         url = rails_url.rails_blob_url(user.pictures.first.variant(:thumb).processed)

--- a/spec/user_file_spec.rb
+++ b/spec/user_file_spec.rb
@@ -174,14 +174,14 @@ RSpec.describe 'Attach file' do
       context 'when "user.pictures=" is called' do
         context 'when it is called with only one picture' do
           it 'attaches a picture to the user' do
-            user.pictures = file
+            user.pictures = [file]
             user.save
 
             expect(user.pictures.attached?).to be
           end
 
           it 'assigns the specified filename' do
-            user.pictures = file
+            user.pictures = [file]
             user.save
 
             expect(user.pictures.first.filename.to_s).to eq(filename)
@@ -191,14 +191,14 @@ RSpec.describe 'Attach file' do
         context 'when it is called with more than one picture' do
           context 'when called with an array' do
             it 'attaches an array of pictures to the user' do
-              user.pictures = pictures_attachments
+              user.pictures = [pictures_attachments]
               user.save
 
               expect(user.pictures.count).to eq(2)
             end
 
             it 'assigns the specified filename' do
-              user.pictures = pictures_attachments
+              user.pictures = [pictures_attachments]
               user.save
 
               expect(user.pictures.first.filename).to eq(filename)
@@ -228,13 +228,13 @@ RSpec.describe 'Attach file' do
       context 'when pictures are passed as a hash parameter' do
         context 'when a single picture is passed' do
           it 'attaches a picture' do
-            user = User.create!(pictures: file)
+            user = User.create!(pictures: [file])
 
             expect(user.pictures.attached?).to be
           end
 
           it 'assigns the specified filename' do
-            user = User.create!(pictures: file)
+            user = User.create!(pictures: [file])
 
             expect(user.pictures.first.filename).to eq(filename)
           end
@@ -258,7 +258,7 @@ RSpec.describe 'Attach file' do
 
       context 'when user already has pictures attached' do
         context 'when user has only one picture attached' do
-          let(:user) { User.create!(pictures: file) }
+          let(:user) { User.create!(pictures: [file]) }
 
           context 'when the user wants to remove the picture' do
             it 'removes the picture' do


### PR DESCRIPTION
### Summary

* **Updated Gemfile for Rails 7.1 support**
The Gemfile has been updated to ensure compatibility with Rails 7.1, keeping the project up-to-date with the latest Rails version.

* **New test added for blank base64 data**
A new test has been added to the user_base64_spec to ensure that blank base64 data is properly handled by the system.

* **Bug fix for assigning pictures with nil or empty string**
A bug related to handling picture assignments via the setter method has been fixed. The issue occurred when the input was either nil or an empty string, and it now correctly handles these cases.