### PR TITLE
fix empty file decode issue

### DIFF
--- a/lib/active_storage_support/base64_attach.rb
+++ b/lib/active_storage_support/base64_attach.rb
@@ -19,7 +19,7 @@ module ActiveStorageSupport
       return unless base64_data.try(:is_a?, String) && base64_data.strip.start_with?('data')
 
       headers, data = base64_data.split(',')
-      decoded_data  = Base64.decode64(data)
+      decoded_data  = Base64.decode64(data || '')
 
       attachment[:io] = StringIO.new(decoded_data)
       attachment[:content_type] ||= content_type(headers)

--- a/spec/dummy/app/models/user.rb
+++ b/spec/dummy/app/models/user.rb
@@ -6,4 +6,6 @@ class User < ApplicationRecord
   has_many_base64_attached :pictures do |attachable|
     attachable.variant :thumb, resize_to_fit: [1, 1]
   end
+
+  has_one_base64_attached :file
 end


### PR DESCRIPTION
### Summary
[issue](https://github.com/rootstrap/active-storage-base64/issues/76)

we get error when there is an empty file is uploaded
the issue happens in the decode process for data part because it is empty

`lib/active_storage_support/base64_attach.rb:22
decoded_data  = Base64.decode64(data)`
here the data is `nil` and will get an error

### Other Information

I think we should consider allowing empty data part to be blank like I did in my PR here or adding validation to allow or prevent empty files
