### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,9 @@
 name: CI
 
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+    branches: [master]
 
 jobs:
   build:
@@ -9,12 +12,17 @@ jobs:
     strategy:
       matrix:
         gemfile: [rails_7_1.gemfile, rails_head.gemfile]
-        ruby_version: [2.7, 3.0, 3.1, 3.2]
+        ruby_version: ['2.7', '3.0', '3.1', '3.2']
+        exclude:
+          - gemfile: rails_head.gemfile
+            ruby_version: '2.7'
+          - gemfile: rails_head.gemfile
+            ruby_version: '3.0'
     env:
       BUNDLE_GEMFILE: gemfiles/${{ matrix.gemfile }}
       CC_TEST_REPORTER_ID: 7196b4aa257fde33f24463218af32db6a6efd23d9148204822f757fa614a093e
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Setup Ruby
       uses: ruby/setup-ruby@v1
       with:
@@ -27,7 +35,7 @@ jobs:
         ./cc-test-reporter before-build
     - name: Build and test with Rake
       run: |
-        gem install bundler
+        gem install bundler -v 2.4.22
         bundle update
         bundle install --gemfile gemfiles/${{ matrix.gemfile }} --jobs 4 --retry 3
         bundle exec rake code_analysis


### PR DESCRIPTION
- Don't run the CI twice (push trigger is only for the main branch)
- Upgrade actions/checkout so it doesn't warn anymore
- Exclude ruby 2.7 and 3.0 from the CI since they no longer work with rails head
- Specify bundler version so that it works with all supported Ruby versions